### PR TITLE
Update depcrecated `sudo: no` to `become: no`.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: "Julien DAUPHANT"
   license: BSD
-  min_ansible_version: 1.7
+  min_ansible_version: 1.9
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,12 +15,12 @@
 
   - local_action: stat path={{ ssl_certs_local_privkey_path }}
     register: stat_privkey
-    sudo: false
+    become: no
     tags: [ssl-certs,configuration]
 
   - local_action: stat path={{ ssl_certs_local_cert_path }}
     register: stat_cert
-    sudo: false
+    become: no
     tags: [ssl-certs,configuration]
 
   - name: Test if privkey file is needed


### PR DESCRIPTION
The `sudo` directive is deprecated and replaced by `become`:
    http://docs.ansible.com/ansible/become.html
