### PR TITLE
Fix #6: 'ssl_certs_local_cert_data' is undefined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,8 +63,8 @@
       mode: "{{ ssl_certs_mode }}"
     when: ssl_certs_local_privkey_data is defined and ssl_certs_local_cert_data is defined
     with_items:
-      - { content: "{{ ssl_certs_local_cert_data }}", dest: "{{ ssl_certs_cert_path }}" }
-      - { content: "{{ ssl_certs_local_privkey_data }}", dest: "{{ ssl_certs_privkey_path }}" }
+      - { content: "{{ ssl_certs_local_cert_data|default }}", dest: "{{ ssl_certs_cert_path }}" }
+      - { content: "{{ ssl_certs_local_privkey_data|default }}", dest: "{{ ssl_certs_privkey_path }}" }
     no_log: true
     tags: [ssl-certs,configuration]
 


### PR DESCRIPTION
Hello guys,

The _with_items_ is evaluated before a task's conditional that is why we run into this error with @anaelChardan (see here https://github.com/ansible/ansible/issues/3134)

I think this fix is clean enough. It avoids to create an empty var and test the value instead of the definition.

++
