### PR TITLE
Make file mode octal `0700` instead of decimal `700`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ ssl_certs_privkey_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.key"
 ssl_certs_cert_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.pem"
 ssl_certs_csr_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.csr"
 ssl_certs_dhparam_path: "{{ssl_certs_path}}/dhparam.pem"
-ssl_certs_mode: 700
+ssl_certs_mode: 0700
 
 ssl_certs_local_privkey_path: "{{inventory_dir|default(playbook_dir)}}/files/ssl/{{ssl_certs_common_name}}.key"
 ssl_certs_local_cert_path: "{{inventory_dir|default(playbook_dir)}}/files/ssl/{{ssl_certs_common_name}}.pem"


### PR DESCRIPTION
This needs to be `0700` instead of `700`.  My permissions were coming out as `d-w-rwxr-T.`, because `700` was interpreted as decimal and then converted to octal (`1274`).

cf. http://docs.ansible.com/ansible/file_module.html

> Leaving off the leading zero will likely have unexpected results.
