### PR TITLE
Don't overwrite existing key/certs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ ssl_certs_cert_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.pem"
 ssl_certs_csr_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.csr"
 ssl_certs_dhparam_path: "{{ssl_certs_path}}/dhparam.pem"
 ssl_certs_mode: 0700
+ssl_certs_overwrite_existing: true
 
 ssl_certs_local_privkey_path: "{{inventory_dir|default(playbook_dir)}}/files/ssl/{{ssl_certs_common_name}}.key"
 ssl_certs_local_cert_path: "{{inventory_dir|default(playbook_dir)}}/files/ssl/{{ssl_certs_common_name}}.pem"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,7 @@
       owner: "{{ ssl_certs_path_owner }}"
       group: "{{ ssl_certs_path_group }}"
       mode: "{{ ssl_certs_mode }}"
+      force: "{{ ssl_certs_overwrite_existing }}"
     when: >
       ( stat_privkey.stat.exists and stat_cert.stat.exists )
       and ( ssl_certs_local_privkey_data is undefined and ssl_certs_local_cert_data is undefined )
@@ -61,6 +62,7 @@
       owner: "{{ ssl_certs_path_owner }}"
       group: "{{ ssl_certs_path_group }}"
       mode: "{{ ssl_certs_mode }}"
+      force: "{{ ssl_certs_overwrite_existing }}"
     when: ssl_certs_local_privkey_data is defined and ssl_certs_local_cert_data is defined
     with_items:
       - { content: "{{ ssl_certs_local_cert_data|default }}", dest: "{{ ssl_certs_cert_path }}" }


### PR DESCRIPTION
I have added a new variable called "ssl_certs_overwrite_existing" that controls if this role should overwrite the existing key/cert files already existing on the computer that you are running Ansible against. I have set its default value to "true".
