### PR TITLE
Added missing quotes to ssl_certs_mode value.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ ssl_certs_privkey_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.key"
 ssl_certs_cert_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.pem"
 ssl_certs_csr_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.csr"
 ssl_certs_dhparam_path: "{{ssl_certs_path}}/dhparam.pem"
-ssl_certs_mode: 0700
+ssl_certs_mode: "0700"
 
 ssl_certs_local_privkey_path: "{{inventory_dir|default(playbook_dir)}}/files/ssl/{{ssl_certs_common_name}}.key"
 ssl_certs_local_cert_path: "{{inventory_dir|default(playbook_dir)}}/files/ssl/{{ssl_certs_common_name}}.pem"


### PR DESCRIPTION
Hi,

Without quotes on ssl_certs_mode value, the task "Ensure ssl folder exist" fails with this error:

```
TASK: [jdauphant.ssl-certs | Ensure ssl folder exist] ************************* 
failed: [192.168.1.70] => (item=default({})) => {"details": "bad symbolic permission for mode: 448", "failed": true, "gid": 0, "group": "root", "item": "default({})", "mode": "0755", "owner": "root", "path": "/
etc/ssl/svr2.xxxx.com", "size": 4096, "state": "directory", "uid": 0}
msg: mode must be in octal or symbolic form
failed: [192.168.1.79] => (item=default({})) => {"details": "bad symbolic permission for mode: 448", "failed": true, "gid": 0, "group": "root", "item": "default({})", "mode": "0755", "owner": "root", "path": "/
etc/ssl/svr1.xxxx.com", "size": 4096, "state": "directory", "uid": 0}
msg: mode must be in octal or symbolic form

FATAL: all hosts have already failed -- aborting

```
