### PR TITLE
Use generic package manager to install openssl

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
   - name: Ensure OpenSSL is installed
-    apt: name=openssl state=present
-    when: ansible_os_family == "Debian"
+    package: name=openssl state=present
     tags: [ssl-certs,packages]
 
   - name: Ensure ssl folder exist


### PR DESCRIPTION
Right now role installs openssl only to debian based distros. Switching to generic package manager instead of apt resolves this problem.