### PR TITLE
Give the ability to unset certificate and private keys data

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,8 @@ ssl_certs_mode: "0700"
 
 ssl_certs_local_privkey_path: "{{inventory_dir|default(playbook_dir)}}/files/ssl/{{ssl_certs_common_name}}.key"
 ssl_certs_local_cert_path: "{{inventory_dir|default(playbook_dir)}}/files/ssl/{{ssl_certs_common_name}}.pem"
+ssl_certs_local_privkey_data: ""
+ssl_certs_local_cert_data: ""
 
 ssl_certs_generate_self_signed: true
 ssl_certs_key_size: "2048"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
   - include: generate.yml
     when: >
       ( not stat_privkey.stat.exists and not stat_cert.stat.exists )
-      and ( ssl_certs_local_privkey_data is undefined and ssl_certs_local_cert_data is undefined )
+      and ( ssl_certs_local_privkey_data == '' and ssl_certs_local_cert_data == '' )
     tags: [ssl-certs,configuration]
 
   - name: Copy SSL certificates
@@ -47,7 +47,7 @@
       mode: "{{ ssl_certs_mode }}"
     when: >
       ( stat_privkey.stat.exists and stat_cert.stat.exists )
-      and ( ssl_certs_local_privkey_data is undefined and ssl_certs_local_cert_data is undefined )
+      and ( ssl_certs_local_privkey_data == '' and ssl_certs_local_cert_data == '' )
     with_items:
       - { src: "{{ ssl_certs_local_cert_path }}", dest: "{{ ssl_certs_cert_path }}" }
       - { src: "{{ ssl_certs_local_privkey_path }}", dest: "{{ ssl_certs_privkey_path }}" }
@@ -60,7 +60,8 @@
       owner: "{{ ssl_certs_path_owner }}"
       group: "{{ ssl_certs_path_group }}"
       mode: "{{ ssl_certs_mode }}"
-    when: ssl_certs_local_privkey_data is defined and ssl_certs_local_cert_data is defined
+    when: ssl_certs_local_privkey_data != ''
+          and ssl_certs_local_cert_data != ''
     with_items:
       - { content: "{{ ssl_certs_local_cert_data|default }}", dest: "{{ ssl_certs_cert_path }}" }
       - { content: "{{ ssl_certs_local_privkey_data|default }}", dest: "{{ ssl_certs_privkey_path }}" }


### PR DESCRIPTION
Hi @jdauphant,

While using your role, I noticed it wasn't easy to unset the certificate and private key data for a specific host or environment.
My use case was to use certificate and private data for all environments except for my development environment where I want to use self-signed certificate.

With this PR, we are now able to generate self signed certificate by unsetting the vars this way
```
ssl_certs_local_privkey_data: ''
ssl_certs_local_cert_data: ''
```

If you have any idea to achieve this in a better way, please let me know.