### PR TITLE
Separate out priv key and cert installs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ ssl_certs_cert_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.pem"
 ssl_certs_csr_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.csr"
 ssl_certs_dhparam_path: "{{ssl_certs_path}}/dhparam.pem"
 ssl_certs_mode: "0700"
+ssl_certs_force_replace: yes
 
 ssl_certs_local_privkey_path: "{{inventory_dir|default(playbook_dir)}}/files/ssl/{{ssl_certs_common_name}}.key"
 ssl_certs_local_cert_path: "{{inventory_dir|default(playbook_dir)}}/files/ssl/{{ssl_certs_common_name}}.pem"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,19 +38,30 @@
       and ( ssl_certs_local_privkey_data == '' and ssl_certs_local_cert_data == '' )
     tags: [ssl-certs,configuration]
 
-  - name: Copy SSL certificates
+  - name: Copy SSL private key file (if exists)
     copy:
-      src: "{{ item.src }}"
-      dest: "{{ item.dest }}"
+      src: "{{ ssl_certs_local_privkey_path }}"
+      dest: "{{ ssl_certs_privkey_path }}"
       owner: "{{ ssl_certs_path_owner }}"
       group: "{{ ssl_certs_path_group }}"
       mode: "{{ ssl_certs_mode }}"
+      force: no
     when: >
-      ( stat_privkey.stat.exists and stat_cert.stat.exists )
-      and ( ssl_certs_local_privkey_data == '' and ssl_certs_local_cert_data == '' )
-    with_items:
-      - { src: "{{ ssl_certs_local_cert_path }}", dest: "{{ ssl_certs_cert_path }}" }
-      - { src: "{{ ssl_certs_local_privkey_path }}", dest: "{{ ssl_certs_privkey_path }}" }
+      ( stat_privkey.stat.exists )
+      and ( ssl_certs_local_privkey_data == '' )
+    tags: [ssl-certs,configuration]
+
+  - name: Copy SSL certificate file (if exists)
+    copy:
+      src: "{{ ssl_certs_local_cert_path }}"
+      dest: "{{ ssl_certs_cert_path }}"
+      owner: "{{ ssl_certs_path_owner }}"
+      group: "{{ ssl_certs_path_group }}"
+      mode: "{{ ssl_certs_mode }}"
+      force: no
+    when: >
+      ( stat_cert.stat.exists )
+      and ( ssl_certs_local_cert_data == '' )
     tags: [ssl-certs,configuration]
 
   - name: Copy SSL certificate data
@@ -60,8 +71,8 @@
       owner: "{{ ssl_certs_path_owner }}"
       group: "{{ ssl_certs_path_group }}"
       mode: "{{ ssl_certs_mode }}"
-    when: ssl_certs_local_privkey_data != ''
-          and ssl_certs_local_cert_data != ''
+      force: no
+    when: item.content != ''
     with_items:
       - { content: "{{ ssl_certs_local_cert_data|default }}", dest: "{{ ssl_certs_cert_path }}" }
       - { content: "{{ ssl_certs_local_privkey_data|default }}", dest: "{{ ssl_certs_privkey_path }}" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
       owner: "{{ ssl_certs_path_owner }}"
       group: "{{ ssl_certs_path_group }}"
       mode: "{{ ssl_certs_mode }}"
-      force: no
+      force: "{{ ssl_certs_force_replace }}"
     when: >
       ( stat_privkey.stat.exists )
       and ( ssl_certs_local_privkey_data == '' )
@@ -58,7 +58,7 @@
       owner: "{{ ssl_certs_path_owner }}"
       group: "{{ ssl_certs_path_group }}"
       mode: "{{ ssl_certs_mode }}"
-      force: no
+      force: "{{ ssl_certs_force_replace }}"
     when: >
       ( stat_cert.stat.exists )
       and ( ssl_certs_local_cert_data == '' )
@@ -71,7 +71,7 @@
       owner: "{{ ssl_certs_path_owner }}"
       group: "{{ ssl_certs_path_group }}"
       mode: "{{ ssl_certs_mode }}"
-      force: no
+      force: "{{ ssl_certs_force_replace }}"
     when: item.content != ''
     with_items:
       - { content: "{{ ssl_certs_local_cert_data|default }}", dest: "{{ ssl_certs_cert_path }}" }


### PR DESCRIPTION
Closes: https://github.com/jdauphant/ansible-role-ssl-certs/issues/30

I took the liberty to split out installing priv key and cert from files too. I had to get rid of with_items. I think this is fine.

While on it, I also added force: "{{ ssl_certs_force_replace }}" to all copy blocks so that the playbook cab be run in ansible idempotent way if needed to be. copy module defaults to force: yes which ends up replacing the file always. This breaks our idempotency check. Some people seem not to care about this. So to not disturb the default behavior, I set `ssl_certs_force_replace` to `yes` which reflects default ansible behavior for copy. 

TODO:

* [x] Figure out how to test. 