### PR TITLE
Change certs owner to apache on redhat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,6 @@ ssl_certs_days: "365"
 ssl_certs_fields: "/C={{ssl_certs_country}}/ST={{ssl_certs_state}}/L={{ssl_certs_locality}}/O={{ssl_certs_organization}}/CN={{ssl_certs_common_name}}"
 
 ssl_certs_path: "/etc/ssl/{{ssl_certs_common_name}}"
-ssl_certs_path_owner: "www-data"
-ssl_certs_path_group: "www-data"
 ssl_certs_privkey_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.key"
 ssl_certs_cert_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.pem"
 ssl_certs_csr_path: "{{ssl_certs_path}}/{{ssl_certs_common_name}}.csr"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+
+  - name: Set OS dependent variables
+    include_vars: "{{ item }}"
+    with_first_found:
+     - "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
+     - "{{ ansible_distribution }}.yml"
+     - "{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
+     - "{{ ansible_os_family }}.yml"
+     - default.yml
+
   - name: Ensure OpenSSL is installed
     package: name=openssl state=present
     tags: [ssl-certs,packages]

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,4 @@
+---
+
+ssl_certs_path_owner: "www-data"
+ssl_certs_path_group: "www-data"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,4 @@
+---
+
+ssl_certs_path_owner: "apache"
+ssl_certs_path_group: "apache"

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,4 @@
+---
+
+ssl_certs_path_owner: "www-data"
+ssl_certs_path_group: "www-data"


### PR DESCRIPTION
This PR allows this role to run on RedHat by correctly setting the apache owner and group on redhat systems.