### PR TITLE
Use DSA-like DH parameters for a huge speed increase

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,7 +80,7 @@
     tags: [ssl-certs,configuration]
 
   - name: Generate strong DHE parameter - https://weakdh.org/
-    command: openssl dhparam -out {{ssl_certs_dhparam_path}} {{ssl_certs_dhparam_size}} creates={{ssl_certs_dhparam_path}}
+    command: openssl dhparam -dsaparam -out {{ssl_certs_dhparam_path}} {{ssl_certs_dhparam_size}} creates={{ssl_certs_dhparam_path}}
     when: ssl_certs_generate_dh_param
     tags: [ssl-certs,configuration]
 


### PR DESCRIPTION
Generating DSA-like DH parameters (`-dsaparam`) is *significantly* faster, and my understanding is that it does not result in less security. I was convinced by this discussion:

https://security.stackexchange.com/questions/95178/diffie-hellman-parameters-still-calculating-after-24-hours/95184